### PR TITLE
Fix ansible version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,7 +21,6 @@ jobs:
         ansible:
           - stable-2.12
           - stable-2.13
-          - devel
     runs-on: ubuntu-latest
     steps:
 
@@ -133,20 +132,9 @@ jobs:
         ansible:
           - stable-2.12
           - stable-2.13
-          - devel
         python:
-          #- 2.6
-          #- 2.7
-          #- 3.5
-          #- 3.6
-          #- 3.7
           - 3.8
-          #- 3.9
         lbry_module: ${{ fromJson(needs.integration_matrix.outputs.matrix) }}
-        exclude:
-          # Because ansible-test doesn't support python3.9 for Ansible 2.9
-          - ansible: stable-2.9
-            python: 3.9
 
     steps:
       - name: Check out code

--- a/.github/workflows/publish_collection.yml
+++ b/.github/workflows/publish_collection.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.8
 
       - name: Install ansible-base (devel)
-        run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+        run: pip install https://github.com/ansible/ansible/archive/stable-2.14.tar.gz --disable-pip-version-check
 
       - name: Build the collection
         run: ansible-galaxy collection build


### PR DESCRIPTION
##### SUMMARY

Fixes ansible version as stable-2.14 requires Python 3.9 which we cannot support (LBRY restrictions)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI